### PR TITLE
Conserta duplicação do whitelist na settings.py

### DIFF
--- a/foodcare/settings.py
+++ b/foodcare/settings.py
@@ -51,6 +51,7 @@ MIDDLEWARE = [
 
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:4200',
+    'http://0.0.0.0:4200',
 )
 
 ROOT_URLCONF = 'foodcare.urls'
@@ -122,10 +123,6 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = '/static/'
-
-CORS_ORIGIN_WHITELIST = (
-    'http://localhost:4200',
-)
 
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (


### PR DESCRIPTION
Conserta duplicação do whitelist na settings.py

## Mudanças propostas 
- Remove duplicata do CORS_ORIGIN_WHITELIST na settings.py